### PR TITLE
modified readmes, added rex-dump for images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ build/*
 
 # Doxygen
 doc/doxygen
+
+# User-dependent files
+CMakeLists.txt.user

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 [![Build Status](https://travis-ci.org/roboticeyes/openrex.svg?branch=master)](https://travis-ci.org/roboticeyes/openrex)
 
-OpenREX is the open source toolkit for the <a href="https://rex.robotic-eyes.com">REX platform</a>. This repository
-contains all the necessary ingredients supporting REX develpers for getting started with REX.
-
 REX is an Augmented Reality platform enabling users to simple embed your 3D content into the real world. REX is
 cross-platform and supports a variety of different devices (e.g. iPhone, Android phones, Microsoft HoloLens). Once the
 3D content is ingested, the models can easily be viewed by any devices using our free app <a
 href="https://www.robotic-eyes.com/download">REX Go</a> and <a href="https://www.robotic-eyes.com/download">REX Holographic</a>
+
+OpenREX is the open source toolkit for the <a href="https://rex.robotic-eyes.com">REX platform</a>. This repository
+contains all the necessary ingredients supporting REX develpers for getting started with REX.
 
 This repository contains the <a href="https://github.com/roboticeyes/openrex/blob/master/doc/rex-spec-v1.md">REX format specification</a>,
 native reader/writer written in C, tools for working with REX files, and debug viewer for displaying REX files.
@@ -51,7 +51,7 @@ the project's root folder. The output will be stored under `doc/doxygen`.
 
 ### Debug viewer
 
-OpenREX contains a simple debug viewer which is able to show the geometry information of a REX file. Currenlty not materials
+OpenREX contains a simple debug viewer which is able to show the geometry information of a REX file. Currently not materials
 are supported! Enable the viewer by
 
 ```
@@ -62,7 +62,7 @@ The debug viewer requires **SDL2** installed on your system including **GLEW**. 
 
 ### Importer (experimental)
 
-There is an experimental REX importer using the Assimp library which is currently not in full production yet. Contribution
+There is an experimental REX importer using the **Assimp** library which is currently not in full production yet. Contribution
 is welcome. To enable the importer use
 
 ```

--- a/doc/rex-spec-v1.md
+++ b/doc/rex-spec-v1.md
@@ -230,7 +230,7 @@ texture information is equally sized to the nrOfVtxCoords. If not available the 
 
 The mesh references a separate material block which is identified by the materialId (dataId of the material block).
 Each DataMesh can only have one material block. This is similar to the `usemtl` in the OBJ file format. **If the
-materialId is `INT64_MAX` (`Long.MAX_VALUE` in Java), then no material is available.**
+materialId is `0x7fffffffffffffffL`, then no material is available.**
 
 The mesh header size is fixed with **128** bytes.
 
@@ -326,7 +326,7 @@ The standard material block is used to set the material for the geometry specifi
 | 4                | Ns           | float    | specular exponent                                       |
 | 4                | alpha        | float    | alpha between 0..1, 1 means full opaque                 |
 
-If no texture is available/set, then the `textureId` is set to `INT64_MAX` (`Long.MAX_VALUE` in Java) value.
+If no texture is available/set, then the `textureId` is set to `0x7fffffffffffffffL` value.
 
 #### DataType PeopleSimulation (6)
 

--- a/doc/rex-spec-v1.md
+++ b/doc/rex-spec-v1.md
@@ -32,9 +32,7 @@ own definition of the coordinate system, so does REX.
 The geometry in REX is defined by a right-handed 3D
 [Cartesian coordinate system](https://en.wikipedia.org/wiki/Cartesian_coordinate_system) as shown in the figure below.
 
-<p align="center">
-<img src="https://github.com/roboticeyes/openrex/raw/coordinate_system/doc/right-handed.png"/>
-</p>
+![Right handed coordinates](/openrex/doc/right-handed.jpg?raw=true "REX coordinate system")
 
 Please make sure that your input geometry is transformed according to our coordinate system specification. As an example,
 if you export FBX from Revit directly, no transformation is required because all the coordinates are already in the
@@ -47,9 +45,7 @@ The triangle orientation is required to be counter-clockwise (CCW), see the exam
 simple example which shows the `coordsys.obj` file from the `data` directory in the viewer, and in real world with the
 REX Go app.
 
-<p align="center">
-<img src="https://github.com/roboticeyes/openrex/raw/coordinate_system/doc/coordinate_example.png"/>
-</p>
+![Coordinate example](/doc/coordinate_example.png?raw=true "Coordinate example")
 
 ### SketchUp
 
@@ -62,9 +58,7 @@ same visualization in REX Go (see screenshot). COLLADA defines the model's coord
 included COLLADA file in the `data` directory has the `up_axis` is defined as `Z_UP`).  This information is interpreted
 and the coordinate transformation of the REX importer is activated accordingly.
 
-<p align="center">
-<img src="https://github.com/roboticeyes/openrex/raw/coordinate_system/doc/sketchup_example.jpg"/>
-</p>
+![Sketchup example](/doc/sketchup_example.jpg?raw=true "Sketchup example")
 
 ## File layout
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories(
     )
 
 # Targets
+add_executable(rex-dump rex-dump.c)
 add_executable(rex-info rex-info.c)
 add_executable(rex-geojson rex-geojson.c cJSON.c)
 add_executable(rex-las rex-las.c)
@@ -14,6 +15,7 @@ add_executable(rex-text rex-text.c)
 add_executable(rex-asset rex-asset.c)
 
 # Linkage
+target_link_libraries(rex-dump openrex-static)
 target_link_libraries(rex-info openrex-static)
 target_link_libraries(rex-geojson openrex-static m)
 target_link_libraries(rex-las openrex-static m)
@@ -25,7 +27,7 @@ target_link_libraries(rex-asset openrex-static)
 # Source includes
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/src)
 
-install( TARGETS rex-info rex-gen rex-asset rex-las rex-text rex-geojson
+install( TARGETS rex-dump rex-info rex-gen rex-asset rex-las rex-text rex-geojson
     RUNTIME DESTINATION bin
     )
 

--- a/tools/rex-dump.c
+++ b/tools/rex-dump.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 Robotic Eyes GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.*
+ */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "rex.h"
+
+void usage (const char *exec)
+{
+    die ("usage: %s filename.rex block_id\n", exec);
+}
+
+int main (int argc, char **argv)
+{
+    if (argc < 3)
+        usage (argv[0]);
+
+    //Should we do proper parameters as input?
+    //sanity check?
+    int64_t requested_id = atoi(argv[2]);
+
+    long sz;
+    uint8_t *buf = read_file_binary (argv[1], &sz);
+    if (buf == NULL)
+        die ("Cannot open REX file %s\n", argv[1]);
+
+    struct rex_header header;
+    uint8_t *ptr = rex_header_read (buf, &header);
+    if (ptr == NULL)
+        die ("Cannot read REX header");
+
+    for (int i = 0; i < header.nr_datablocks; i++)
+    {
+        //TODO move pointer without reading the block for speedup
+        struct rex_block block;
+        ptr = rex_block_read (ptr, &block);
+
+        //dump selected block
+        if (block.id == (uint64_t) requested_id)
+        {
+            if(block.type == Image)
+            {
+                struct rex_image *img = block.data;
+                fwrite(img->data, sizeof(uint8_t), img->sz, stdout);
+            }
+        }
+
+        //free allocated memory
+        if (block.type == Image)
+        {
+            struct rex_image *img = block.data;
+            FREE (img->data);
+            FREE (block.data);
+        }
+        else if (block.type == LineSet)
+        {
+            struct rex_lineset *ls = block.data;
+            FREE (ls->vertices);
+            FREE (block.data);
+        }
+        else if (block.type == PointList)
+        {
+            struct rex_pointlist *p = block.data;
+            FREE (p->positions);
+            FREE (block.data);
+        }
+        else if (block.type == Text)
+        {
+            FREE (block.data);
+        }
+        else if (block.type == Mesh)
+        {
+            struct rex_mesh *mesh = block.data;
+            rex_mesh_free (mesh);
+            FREE (block.data);
+        }
+        else if (block.type == MaterialStandard)
+        {
+            FREE (block.data);
+        }
+        else if (block.type == UnityPackage)
+        {
+            struct rex_unitypackage *unity = block.data;
+            FREE (unity->data);
+            FREE (block.data);
+        }
+    }
+    FREE (buf);
+    return 0;
+}


### PR DESCRIPTION
Added a rex-dump function which given rex file and datablock id it dumps it to stdout. Currently only the image datablock is dumpable but could easily be extended to other datablocks. `rex-dump house.rex 106 | feh -` as an example usage.

It's suboptimal to read all blocks since we only need one, which in addition then obfuscates the code by freeing the allocated memory that we didn't really need. 

To fix this it should be able to read each header and skip or continue if id matches. That means splitting the `rex_block_read` function between header and data read and letting the rex-dump decide whether to advance the file pointer or not after the header has been read.

Of course that increases the complexity of rex_bock.c so it's all relative to how much we need speed given our current and future rex file sizes.